### PR TITLE
Gopkg: Fix fsnotify import path

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -98,7 +98,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "gopkg.in/fsnotify.v1"
+  name = "gopkg.in/fsnotify/fsnotify.v1"
   packages = ["."]
   revision = "836bfd95fecc0f1511dd66bdbf2b5b61ab8b00b6"
   version = "v1.2.11"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,5 +36,5 @@
   name = "google.golang.org/api"
 
 [[constraint]]
-  name = "gopkg.in/fsnotify.v1"
+  name = "gopkg.in/fsnotify/fsnotify.v1"
   version = "~1.2.0"

--- a/watcher.go
+++ b/watcher.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"gopkg.in/fsnotify.v1"
+	"gopkg.in/fsnotify/fsnotify.v1"
 )
 
 func WaitForReplacement(filename string, op fsnotify.Op,


### PR DESCRIPTION
fsnotify dev team posted:
twitter.com/fsnotify/status/976222199752224768

Example error manifestation:
$ wget https://gopkg.in/fsnotify.v1
--2018-03-20 16:15:33--  https://gopkg.in/fsnotify.v1
Resolving gopkg.in (gopkg.in)... 45.33.37.13
Connecting to gopkg.in (gopkg.in)|45.33.37.13|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2018-03-20 16:15:35 ERROR 404: Not Found.